### PR TITLE
Add example of link to a function definition in Haddock

### DIFF
--- a/haskell-style.md
+++ b/haskell-style.md
@@ -451,6 +451,14 @@ if:
 
 * Only for the first occurrence of each API name in the comment (don't
   bother repeating a link)
+  
+In the following example, the user of the function may need to call
+`normalise`, so a link to the definition of `normalise` is added:
+
+```haskell
+-- | Precondition: levels are 'normalise'd.
+equalLevel' :: forall m. MonadConversion m => Level -> Level -> m ()
+```
 
 Naming
 ------


### PR DESCRIPTION
I had to look up the syntax for links to definitions in Haddock. 
Hopefully this example will save others from doing that.
Also, I think it's a good example of a use case for links.